### PR TITLE
custom middleware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ jspm_packages
 
 # Build directory
 build
+
+# Middleware build files
+middleware.js*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+1.1.0 / 2017-07-10
+==================
+  * Add middleware that can be used instead of `redux-thunk` if desired
+
 1.0.2 / 2017-07-02
 ==================
   * Fix typos in package.json

--- a/README.md
+++ b/README.md
@@ -81,9 +81,31 @@ describe('reloadActiveItem', () => {
 });
 ```
 
-Note: Behind the scenes, `selectorAction` relies on `redux-thunk` to access the store’s `dispatch`
-and `getState` functions . This means you still need to use `redux-thunk` as a middleware when using
-this library.
+## middleware
+
+If you're already using [`redux-thunk`](https://github.com/gaearon/redux-thunk), you don't need to
+do anything to start using `selectorAction` - it’s fully compatible with the thunk middleware.
+
+If you don’t _want_ to use `redux-thunk` (and there are some
+[good](https://twitter.com/intelligibabble/status/800103510624727040)
+[reasons](http://blog.isquaredsoftware.com/2017/01/idiomatic-redux-thoughts-on-thunks-sagas-abstraction-and-reusability/)
+to not want to
+), then `selector-action` provides a middleware for you to use instead:
+
+```js
+import { createStore, applyMiddleware } from 'redux';
+import selectorActionMiddleware from 'selector-action/middleware';
+import rootReducer from './reducers/index';
+
+const store = createStore(
+  rootReducer,
+  applyMiddleware(selectorActionMiddleware),
+);
+```
+
+`selector-action`'s middleware only runs when `selectorAction`s are dispatched. Similar to
+`redux-thunk`, it plays nice with other common middlewares like
+[`redux-pack`](https://github.com/lelandrichardson/redux-pack).
 
 ## Other features
 
@@ -115,7 +137,7 @@ export const awesomeAction = selectorAction([
 ], (foo, bar) => ({ type: 'AWESOME!', payload: { foo, bar } }));
 ```
 
-#### Using `selectorAction` as a thunk
+#### Using `selectorAction` with other action arguments
 
 You may run across a case where an action creator needs a mix of selector results and
 regular arguments to compute an action. For instance, let’s say that the user has entered a new name
@@ -130,11 +152,6 @@ export function setActiveItemName(newName) {
   }));
 }
 ```
-
-`selectorAction` normally returns a generated action creator that takes no arguments.
-However, if it is called with `dispatch` and `getState` as args, then it will return
-a _thunk action_ instead. That's why this example works without having to call the result of
-`selectorAction` as a function.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "selector-action",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "State-aware Redux actions with Reselect syntax.",
   "main": "build/selectorAction.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -10,9 +10,10 @@
     "tests-only": "mocha",
     "test": "npm run tests-only",
     "lint": "eslint .",
-    "build": "mkdirp build && babel src --out-dir build --source-maps",
+    "build": "mkdirp build && babel src --out-dir build --source-maps && npm run build:middleware",
+    "build:middleware": "babel src/middleware.js --out-file middleware.js --source-maps",
     "prepublish": "npm run build",
-    "clean": "rimraf build && rimraf coverage"
+    "clean": "rimraf build && rimraf coverage && rimraf middleware.js{,.map}"
   },
   "repository": {
     "type": "git",

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -1,0 +1,14 @@
+// Adapted from redux-thunk (https://github.com/gaearon/redux-thunk)
+
+function createModifiedThunkMiddleware() {
+  return ({ dispatch, getState }) => next => (action) => {
+    if (typeof action === 'function' && action.IS_SELECTOR_ACTION) {
+      return action(dispatch, getState);
+    }
+
+    return next(action);
+  };
+}
+
+const thunk = createModifiedThunkMiddleware();
+export default thunk;

--- a/src/selectorAction.js
+++ b/src/selectorAction.js
@@ -14,11 +14,12 @@ function selectorAction(...args) {
     if (typeof selector !== 'function') throw new Error('Selectors must be functions');
   });
   const generatedActionCreator = function generatedActionCreator(dispatchArg, getStateArg) {
-    const action = (dispatch, getState) => {
+    const action = function internalGeneratedSelectorAction(dispatch, getState) {
       const state = getState();
       const appliedSelectors = selectors.map(selector => selector(state));
       return dispatch(actionCreator(...appliedSelectors, state));
     };
+    action.IS_SELECTOR_ACTION = true;
     // If this action creator is called as a thunk, we can dispatch directly.
     if (dispatchArg && getStateArg) {
       return action(dispatchArg, getStateArg);
@@ -28,6 +29,7 @@ function selectorAction(...args) {
   };
   // expose the original action creator for testing
   generatedActionCreator.originalActionCreator = actionCreator;
+  generatedActionCreator.IS_SELECTOR_ACTION = true;
   return generatedActionCreator;
 }
 

--- a/test/middleware-tests.js
+++ b/test/middleware-tests.js
@@ -1,0 +1,117 @@
+import chai from 'chai';
+import thunkMiddleware from '../src/middleware';
+import selectorAction from '../src/selectorAction';
+
+describe('custom thunk middleware', () => {
+  const doDispatch = () => {};
+  const doGetState = () => {};
+  const nextHandler = thunkMiddleware({ dispatch: doDispatch, getState: doGetState });
+
+  it('must return a function to handle next', () => {
+    chai.assert.isFunction(nextHandler);
+    chai.assert.strictEqual(nextHandler.length, 1);
+  });
+
+  describe('handle next', () => {
+    it('must return a function to handle action', () => {
+      const actionHandler = nextHandler();
+
+      chai.assert.isFunction(actionHandler);
+      chai.assert.strictEqual(actionHandler.length, 1);
+    });
+
+    describe('handle action', () => {
+      it('must run the given action as a thunk if IS_SELECTOR_ACTION = true', (done) => {
+        const actionHandler = nextHandler();
+        const action = (dispatch, getState) => {
+          chai.assert.strictEqual(dispatch, doDispatch);
+          chai.assert.strictEqual(getState, doGetState);
+          done();
+        };
+        action.IS_SELECTOR_ACTION = true;
+        actionHandler(action);
+      });
+
+      it('must pass action to next if not a function', (done) => {
+        const actionObj = {};
+
+        const actionHandler = nextHandler((action) => {
+          chai.assert.strictEqual(action, actionObj);
+          done();
+        });
+
+        actionHandler(actionObj);
+      });
+
+      it('must pass action to next if it is a function but IS_SELECTOR_ACTION != true', (done) => {
+        const actionFunc = () => {};
+
+        const actionHandler = nextHandler((action) => {
+          chai.assert.strictEqual(action, actionFunc);
+          done();
+        });
+
+        actionHandler(actionFunc);
+      });
+
+      it('must return the return value of next if not a function', () => {
+        const expected = 'redux';
+        const actionHandler = nextHandler(() => expected);
+
+        const outcome = actionHandler();
+        chai.assert.strictEqual(outcome, expected);
+      });
+
+      it('must return the return value of next IS_SELECTOR_ACTION != true', () => {
+        const expected = 'redux';
+        const actionHandler = nextHandler(() => expected);
+
+        const outcome = actionHandler(() => {});
+        chai.assert.strictEqual(outcome, expected);
+      });
+
+      it('must return value as expected if a function and IS_SELECTOR_ACTION = true', () => {
+        const expected = 'rocks';
+        const actionHandler = nextHandler();
+        const action = () => expected;
+        action.IS_SELECTOR_ACTION = true;
+
+        const outcome = actionHandler(action);
+        chai.assert.strictEqual(outcome, expected);
+      });
+
+      it('must be invoked synchronously if a function', () => {
+        const actionHandler = nextHandler();
+        let mutated = 0;
+        const action = () => mutated++;
+        action.IS_SELECTOR_ACTION = true;
+
+        actionHandler(action);
+        chai.assert.strictEqual(mutated, 1);
+      });
+
+      it('works with selectorAction', () => {
+        // selectorAction will dispatch once internally before finally calculating the action
+        // so we use the identity function to assert that the right thing got returned eventually
+        const nextHandlerWithIdentityDispatch =
+          thunkMiddleware({ dispatch: x => x, getState: doGetState });
+        const expected = 'rocks';
+        const actionHandler = nextHandlerWithIdentityDispatch();
+        const action = selectorAction(() => expected);
+
+        const outcome = actionHandler(action);
+        chai.assert.strictEqual(outcome, expected);
+      });
+    });
+  });
+
+  describe('handle errors', () => {
+    it('must throw if argument is non-object', (done) => {
+      try {
+        thunkMiddleware();
+      } catch (err) {
+        done();
+      }
+    });
+  });
+});


### PR DESCRIPTION
Add in a sweet middleware that could be used instead of `redux-thunk`. It's basically `redux-thunk` but it will only run for `selectorActions` - making it easy to test but hard to shoot yourself in the foot with.